### PR TITLE
Stepped Thinking Command

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ import {
     substituteParams,
     updateMessageBlock,
 } from '../../../../script.js';
+import { SlashCommandParser } from '../../../slash-commands/SlashCommandParser.js';
+import { SlashCommand } from '../../../slash-commands/SlashCommand.js';
 import { hideChatMessageRange } from '../../../chats.js';
 import { getMessageTimeStamp } from '../../../RossAscends-mods.js';
 
@@ -327,6 +329,9 @@ async function onGenerationAfterCommands(type) {
     generationType = type;
     isGenerationStopped = false;
 
+    if (!settings.is_enabled || isThinking) {
+        return;
+    }
     if (getContext().groupId) {
         return;
     }
@@ -341,6 +346,9 @@ async function onGenerationAfterCommands(type) {
  * @returns {Promise<void>}
  */
 async function onGroupMemberDrafted() {
+    if (!settings.is_enabled || isThinking) {
+        return;
+    }
     if (isGenerationStopped) {
         return;
     }
@@ -385,10 +393,6 @@ export function stopThinking(textarea) {
  * @returns {Promise<void>}
  */
 export async function runThinking(textarea) {
-    if (!settings.is_enabled || isThinking) {
-        return;
-    }
-
     const context = getContext();
     if (settings.excluded_characters.includes(context.characters[context.characterId].name)) {
         await hideThoughts();
@@ -623,6 +627,14 @@ function replaceThoughtsPlaceholder(substitution) {
     const thoughtsPlaceholder = settings.thoughts_framing + settings.thoughts_placeholder + settings.thoughts_framing;
     return thoughtsPlaceholder.replace('{{thoughts}}', substitution);
 }
+
+SlashCommandParser.addCommandObject(SlashCommand.fromProps({
+	name: 'steppedthinking-trigger',
+	callback: async () => {
+		await runThinking($('#send_textarea'));
+	},
+	helpString: 'Trigger Stepped Thinking via command/QR[Only 1 on 1 chats].',
+}));
 
 //
 


### PR DESCRIPTION
Allows SteppedThinking to be used with commands that change prompts or sampler settings before triggering. (Like `/preset` or `/inject` for example)

~However, since I know near nothing about JS let alone about making ST extensions, I've only got it to work for 1 on 1 chats.~

Edit: I've misunderstood how group chats work. The command works in group chats if you set it to `Execute on group member draft` in the QR menu.