### PR TITLE
Add a setting to send Thoughts messages as the System role

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -126,7 +126,7 @@ async function hideThoughts() {
 
     let promises = [];
     const lastMessageIndex = context.chat.length - 1;
-    for (let i = lastMessageIndex, thoughtsCount = []; lastMessageIndex - i < settings.max_hiding_thoughts_lookup; i--) {
+    for (let i = lastMessageIndex, thoughtsCount = []; i >= 0 && (lastMessageIndex - i < settings.max_hiding_thoughts_lookup); i--) {
         if (Boolean(context.chat[i]?.is_thoughts)) {
             const chatThoughtName = context.chat[i].thoughts_for || context.chat[i].name;
             thoughtsCount[chatThoughtName] ??= 0;

--- a/engine.js
+++ b/engine.js
@@ -266,10 +266,10 @@ async function sendCharacterThoughts(character, text) {
 
     const bias = extractMessageBias(mesText);
     const isSystem = bias && !removeMacros(mesText).length;
-    const isNarrator = settings.thoughts_as_system
+    const isAsSystem = settings.thoughts_as_system
 
     const message = {
-        name: isNarrator ? `${character.name}'s Thoughts` : character.name,
+        name: isAsSystem ? `${character.name}'s Thoughts` : character.name,
         is_user: false,
         is_system: isSystem,
         is_thoughts: true,
@@ -277,7 +277,7 @@ async function sendCharacterThoughts(character, text) {
         send_date: getMessageTimeStamp(),
         mes: substituteParams(mesText),
         extra: {
-            type: isNarrator ? 'narrator' : undefined,
+            type: isAsSystem ? 'narrator' : undefined,
             bias: bias.trim().length ? bias : null,
             gen_id: Date.now(),
             isSmallSys: false,
@@ -299,7 +299,7 @@ async function sendCharacterThoughts(character, text) {
     }];
 
     const context = getContext();
-    if (context.groupId || isNarrator) {
+    if (context.groupId || isAsSystem) {
         message.original_avatar = character.avatar;
         message.force_avatar = context.getThumbnailUrl('avatar', character.avatar);
     }

--- a/engine.js
+++ b/engine.js
@@ -122,22 +122,23 @@ async function hideThoughts() {
     const characterSettings = getCurrentCharacterSettings();
 
     const isMindReaderCharacter = Boolean(characterSettings && characterSettings.is_mind_reader);
-    const hasAccessToThought = (chatCharacter) => isMindReaderCharacter || chatCharacter.name === currentCharacter.name;
+    const hasAccessToThought = (chatCharacter) => isMindReaderCharacter || chatCharacter.thoughts_for === currentCharacter.name;
 
     let promises = [];
     const lastMessageIndex = context.chat.length - 1;
     for (let i = lastMessageIndex, thoughtsCount = []; lastMessageIndex - i < settings.max_hiding_thoughts_lookup; i--) {
+        if (i < 0) break;
         if (Boolean(context.chat[i]?.is_thoughts)) {
             const chatCharacter = context.chat[i];
-            thoughtsCount[chatCharacter.name] ??= 0;
+            thoughtsCount[chatCharacter.thoughts_for] ??= 0;
 
-            if (thoughtsCount[chatCharacter.name] < maxThoughts && hasAccessToThought(chatCharacter)) {
+            if (thoughtsCount[chatCharacter.thoughts_for] < maxThoughts && hasAccessToThought(chatCharacter)) {
                 promises.push(hideChatMessageRange(i, i, true));
             } else {
                 promises.push(hideChatMessageRange(i, i, false));
             }
 
-            thoughtsCount[chatCharacter.name]++;
+            thoughtsCount[chatCharacter.thoughts_for]++;
         }
     }
 
@@ -267,15 +268,18 @@ async function sendCharacterThoughts(character, text) {
 
     const bias = extractMessageBias(mesText);
     const isSystem = bias && !removeMacros(mesText).length;
+    const isNarrator = settings.thoughts_as_system
 
     const message = {
-        name: character.name,
+        name: isNarrator ? `${character.name}'s Thoughts` : character.name,
         is_user: false,
         is_system: isSystem,
         is_thoughts: true,
+        thoughts_for: character.name,
         send_date: getMessageTimeStamp(),
         mes: substituteParams(mesText),
         extra: {
+            type: isNarrator ? 'narrator' : undefined,
             bias: bias.trim().length ? bias : null,
             gen_id: Date.now(),
             isSmallSys: false,
@@ -297,7 +301,7 @@ async function sendCharacterThoughts(character, text) {
     }];
 
     const context = getContext();
-    if (context.groupId) {
+    if (context.groupId || isNarrator) {
         message.original_avatar = character.avatar;
         message.force_avatar = context.getThumbnailUrl('avatar', character.avatar);
     }

--- a/engine.js
+++ b/engine.js
@@ -122,23 +122,21 @@ async function hideThoughts() {
     const characterSettings = getCurrentCharacterSettings();
 
     const isMindReaderCharacter = Boolean(characterSettings && characterSettings.is_mind_reader);
-    const hasAccessToThought = (chatCharacter) => isMindReaderCharacter || chatCharacter.thoughts_for === currentCharacter.name;
+    const hasAccessToThought = (chatThoughtName) => isMindReaderCharacter || chatThoughtName === currentCharacter.name;
 
     let promises = [];
     const lastMessageIndex = context.chat.length - 1;
     for (let i = lastMessageIndex, thoughtsCount = []; lastMessageIndex - i < settings.max_hiding_thoughts_lookup; i--) {
-        if (i < 0) break;
         if (Boolean(context.chat[i]?.is_thoughts)) {
-            const chatCharacter = context.chat[i];
-            thoughtsCount[chatCharacter.thoughts_for] ??= 0;
-
-            if (thoughtsCount[chatCharacter.thoughts_for] < maxThoughts && hasAccessToThought(chatCharacter)) {
+            const chatThoughtName = context.chat[i].thoughts_for || context.chat[i].name;
+            thoughtsCount[chatThoughtName] ??= 0;
+            if (thoughtsCount[chatThoughtName] < maxThoughts && hasAccessToThought(chatThoughtName)) {
                 promises.push(hideChatMessageRange(i, i, true));
             } else {
                 promises.push(hideChatMessageRange(i, i, false));
             }
 
-            thoughtsCount[chatCharacter.thoughts_for]++;
+            thoughtsCount[chatThoughtName]++;
         }
     }
 

--- a/engine.js
+++ b/engine.js
@@ -266,7 +266,7 @@ async function sendCharacterThoughts(character, text) {
 
     const bias = extractMessageBias(mesText);
     const isSystem = bias && !removeMacros(mesText).length;
-    const isAsSystem = settings.thoughts_as_system
+    const isAsSystem = settings.thoughts_as_system;
 
     const message = {
         name: isAsSystem ? `${character.name}'s Thoughts` : character.name,

--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ export const defaultCommonSettings = {
     'is_wian_skipped': false,
     'is_thinking_popups_enabled': true,
     'is_thoughts_spoiler_open': false,
+    'thoughts_as_system': false,
     'max_thoughts_in_prompt': 2,
     'generation_delay': 0.0,
     'max_response_length': 0,
@@ -74,6 +75,7 @@ export function loadCommonSettings() {
     $('#stepthink_is_wian_skipped').prop('checked', settings.is_wian_skipped).trigger('input');
     $('#stepthink_is_thoughts_spoiler_open').prop('checked', settings.is_thoughts_spoiler_open).trigger('input');
     $('#stepthink_is_thinking_popups_enabled').prop('checked', settings.is_thinking_popups_enabled).trigger('input');
+    $('#stepthink_thoughts_as_system').prop('checked', settings.thoughts_as_system).trigger('input');
 }
 
 /**
@@ -84,6 +86,7 @@ export function registerCommonSettingListeners() {
     $('#stepthink_is_wian_skipped').on('input', onCheckboxInput('is_wian_skipped'));
     $('#stepthink_is_thoughts_spoiler_open').on('input', onCheckboxInput('is_thoughts_spoiler_open'));
     $('#stepthink_is_thinking_popups_enabled').on('input', onCheckboxInput('is_thinking_popups_enabled'));
+    $('#stepthink_thoughts_as_system').on('input', onCheckboxInput('thoughts_as_system'));
     $('#stepthink_regexp_to_sanitize').on('input', onRegexpToSanitizeChanged);
     $('#stepthink_max_thoughts_in_prompt').on('input', onIntegerTextareaInput('max_thoughts_in_prompt'));
     $('#stepthink_max_response_length').on('input', onIntegerTextareaInput('max_response_length'));

--- a/settings.html
+++ b/settings.html
@@ -31,6 +31,14 @@
                 </label>
             </div>
 
+            <div class="flex-container marginTopBot5">
+                <label class="checkbox_label expander" for="stepthink_thoughts_as_system"
+                       title="Include character thoughts messages as the System role.">
+                    <input id="stepthink_thoughts_as_system" type="checkbox"/>
+                    Thoughts as System
+                </label>
+            </div>
+
             <hr/>
 
             <div class="flex-container marginTopBot5">


### PR DESCRIPTION
System thought messages are renamed to "Character's Thoughts" to differentiate for instruct templates that use names for all message roles and are otherwise formatted as system-role messages.

Defaults to "off" to preserve current functionality.