### PR TITLE
Use markdown langcode in thought blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ export const defaultCommonSettings = {
 
     // Not in UI, since the settings are unlikely to be changed
     'thoughts_framing': '```',
-    'thoughts_placeholder': 'st\n{{thoughts}}\n',
+    'thoughts_placeholder': 'md\n{{thoughts}}\n',
     'default_thoughts_substitution': '...',
     'thinking_summary_placeholder': 'Thinking ({{char}}) 💭',
     'max_hiding_thoughts_lookup': 200,


### PR DESCRIPTION
Very minor QoL change you can feel free to ignore if it was `st` for a reason, but I think it makes the thought code blocks look nicer :eyes: (Doesn't affect and isn't affected by older thought posts since it's just the template for filling in the messages.)

Before:
![image](https://github.com/user-attachments/assets/9b5a41a6-9f35-412c-b6fe-f3abe69074cb)

After:
![image](https://github.com/user-attachments/assets/74f06f7f-50d7-4796-9bac-0c92dfc550ce)
