### PR TITLE
Fix 'normal' mode refusing to generate

### DIFF
--- a/thinking/engine.js
+++ b/thinking/engine.js
@@ -503,7 +503,7 @@ function isGenerationTypeAllowed(type) {
             return false;
         }
     } else {
-        if (type) {
+        if (type !== 'normal') {
             return false;
         }
     }


### PR DESCRIPTION
Non-group chat regular generation is now always using the 'normal' mode for all regular prompt generations.